### PR TITLE
Allow users to choose VPN server before purchase

### DIFF
--- a/app/bot/models/subscription_data.py
+++ b/app/bot/models/subscription_data.py
@@ -11,3 +11,4 @@ class SubscriptionData(CallbackData, prefix="subscription"):
     devices: int = 0
     duration: int = 0
     price: float = 0
+    server_id: int = 0

--- a/app/bot/payment_gateways/_gateway.py
+++ b/app/bot/payment_gateways/_gateway.py
@@ -133,6 +133,7 @@ class PaymentGateway(ABC):
                     user=user,
                     devices=data.devices,
                     duration=data.duration,
+                    server_id=data.server_id or None,
                 )
                 logger.info(f"Subscription created for user {user.tg_id}")
                 key = await self.services.vpn.get_key(user)

--- a/app/bot/utils/navigation.py
+++ b/app/bot/utils/navigation.py
@@ -37,6 +37,7 @@ class NavSubscription(str, Enum):
     CHANGE = "change"
     EXTEND = "extend"
     PROCESS = "process"
+    SERVER = "server"
     DEVICES = "devices"
     DURATION = "duration"
     PROMOCODE = "promocode"

--- a/app/locales/en/LC_MESSAGES/bot.po
+++ b/app/locales/en/LC_MESSAGES/bot.po
@@ -947,6 +947,10 @@ msgstr "💳 Extend subscription"
 msgid "subscription:button:activate_promocode"
 msgstr "🎟️ Activate promocode"
 
+#: app/bot/routers/subscription/keyboard.py:84
+msgid "subscription:button:change_server"
+msgstr "◀️ Change server"
+
 #: app/bot/routers/subscription/keyboard.py:111
 msgid "subscription:button:change_devices"
 msgstr "◀️ Change number of devices"
@@ -1070,10 +1074,20 @@ msgstr "⏳ <b>Specify the duration:</b>"
 msgid "subscription:message:devices"
 msgstr "📱 <b>Select the number of devices:</b>"
 
+#: app/bot/routers/subscription/subscription_handler.py:164
+#: app/bot/routers/subscription/subscription_handler.py:200
+msgid "subscription:message:server"
+msgstr "🌐 <b>Select a server:</b>\n\nChoose the server you want to use for your subscription."
+
 #: app/bot/routers/subscription/subscription_handler.py:138
 #: app/bot/routers/subscription/trial_handler.py:35
 msgid "subscription:popup:no_available_servers"
 msgstr "❌ No available servers found. Please try again later."
+
+#: app/bot/routers/subscription/subscription_handler.py:189
+#: app/bot/routers/subscription/subscription_handler.py:215
+msgid "subscription:popup:server_unavailable"
+msgstr "❌ The selected server is no longer available. Please choose another one."
 
 #: app/bot/routers/subscription/subscription_handler.py:181
 msgid "subscription:message:payment_method"

--- a/app/locales/ru/LC_MESSAGES/bot.po
+++ b/app/locales/ru/LC_MESSAGES/bot.po
@@ -958,6 +958,10 @@ msgstr "💳 Продлить подписку"
 msgid "subscription:button:activate_promocode"
 msgstr "🎟️ Активировать промокод"
 
+#: app/bot/routers/subscription/keyboard.py:84
+msgid "subscription:button:change_server"
+msgstr "◀️ Изменить сервер"
+
 #: app/bot/routers/subscription/keyboard.py:111
 msgid "subscription:button:change_devices"
 msgstr "◀️ Изменить количество устройств"
@@ -1083,10 +1087,20 @@ msgstr "⏳ <b>Выберите длительность:</b>"
 msgid "subscription:message:devices"
 msgstr "📱 <b>Выберите количество устройств:</b>"
 
+#: app/bot/routers/subscription/subscription_handler.py:164
+#: app/bot/routers/subscription/subscription_handler.py:200
+msgid "subscription:message:server"
+msgstr "🌐 <b>Выберите сервер:</b>\n\nУкажите сервер, на котором хотите использовать подписку."
+
 #: app/bot/routers/subscription/subscription_handler.py:138
 #: app/bot/routers/subscription/trial_handler.py:35
 msgid "subscription:popup:no_available_servers"
 msgstr "❌ Доступных серверов не найдено. Попробуйте позже."
+
+#: app/bot/routers/subscription/subscription_handler.py:189
+#: app/bot/routers/subscription/subscription_handler.py:215
+msgid "subscription:popup:server_unavailable"
+msgstr "❌ Выбранный сервер больше недоступен. Пожалуйста, выберите другой."
 
 #: app/bot/routers/subscription/subscription_handler.py:181
 msgid "subscription:message:payment_method"


### PR DESCRIPTION
## Summary
- add an explicit server selection step to the subscription purchase flow and allow changing the server later
- let the server pool expose the available servers and respect a user-selected server during client creation
- update subscription data payloads and localizations to store the chosen server

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc139b39c483318d4b5ef400a01707